### PR TITLE
Fix resize to parse heigth and width from viewBox

### DIFF
--- a/lib/resize.js
+++ b/lib/resize.js
@@ -40,8 +40,9 @@ function resize(dir, fn){
    */
 
   var svg = read(paths.svg, 'utf8');
-  var width = parseFloat(match(/<svg[\s\S]*?width="([\.\d]+)/m, svg), 10);
-  var height = parseFloat(match(/<svg[\s\S]*?height="([\.\d]+)/m, svg), 10);
+  var viewBox = getDims(match(/<svg[\s\S]*?viewBox="([\.\s\d]+)/m, svg));
+  var width = viewBox.width;
+  var height = viewBox.height;
 
   if (!width) return fn(new Error('svg has no width property'));
   if (!height) return fn(new Error('svg has no height property'));
@@ -145,3 +146,25 @@ function shorthand(string){
 
   return ret;
 }
+
+/**
+ * Parse width and height from viewBox string
+ *
+ * @param {String} string
+ * @return {Object}
+ */
+
+function getDims(string){
+  string = string || '';
+  var ret = {};
+  var parts = string.split(' ').map(function(str) { return parseFloat(str, 10); });
+  ret.width = parts[2];
+  ret.height = parts[3];
+
+  return ret;
+}
+
+
+
+
+


### PR DESCRIPTION
@ianstormtaylor @calvinfo fixes https://github.com/logo/cli/issues/6

basically parsing the width and height params from the viewBox because newer versions of AI seem to be omitting width and height from the svg tag. 
